### PR TITLE
Ensure biopython version is less than 1.78 which removes alphabet

### DIFF
--- a/MetaBGC-Development/setup.py
+++ b/MetaBGC-Development/setup.py
@@ -14,7 +14,7 @@ install_requires = [
     'numpy',
     'matplotlib',
     'scipy',
-    'biopython >= 1.72',
+    'biopython >= 1.72, < 1.78',
     'scikit-learn >= 0.20.1',
     'pandas >= 0.19.2',
     'rpy2 >= 2.9.1'


### PR DESCRIPTION
The latest biopython (1.78) removes alphabet which is used in createsphmms.py

As a quickfix I restricted the biopython version to less than 1.78

See https://biopython.org/wiki/Alphabet for info on the removal.

